### PR TITLE
Updating node-sass to fix install errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Johnny Benson",
   "dependencies": {
     "through2": "~0.4.1",
-    "node-sass": "~0.8.1",
+    "node-sass": "~2.0.1",
     "underscore": "~1.6.0"
   }
 }


### PR DESCRIPTION
This updates the `node-sass` version to the latest stable release which fixes _*critical*_ install errors with `node-sass` on OS X Yosemite.

[Installation Failing (on Linux, Windows or Heroku etc.) · Issue #467 · sass/node-sass](https://github.com/sass/node-sass/issues/467#issuecomment-74405623)

