### PR TITLE
Bump node-sass.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "3.10.x",
-    "node-sass": "3.0.x",
+    "node-sass": "3.2.x",
     "through2": "2.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps it to `3.2.x`.