### PR TITLE
Add autoprefixer support

### DIFF
--- a/lib/sassr.js
+++ b/lib/sassr.js
@@ -4,6 +4,8 @@ var path = require('path');
 
 var _ = require('lodash');
 var sass = require('node-sass');
+var postcss = require('postcss');
+var autoprefixer = require('autoprefixer');
 var through = require('through2');
 
 var SASS_EXTENSION_RE = /\.(css|scss)$/;
@@ -11,8 +13,7 @@ var SASS_DEFAULTS = {
     includePaths: [],
     outputStyle: 'compressed'
 };
-var OMIT_FIELDS = ['file', 'success', 'error'];
-var ERROR_RE = /console\.error\((.*?)\)/;
+var AUTOPREFIXER_DEFAULTS = {};
 
 function sassrModuleWith(css) {
     return [
@@ -51,40 +52,17 @@ function sassrModuleWith(css) {
     ].join('\n');
 }
 
-function errorModuleWith(message) {
-    return [
-        '\'use strict\';',
-        '',
-        'exports.getStyleElement = function() {',
-        '    return null;',
-        '};',
-        '',
-        'exports.getCSSText = function() {',
-        '    return \'\';',
-        '};',
-        '',
-        'exports.append = exports.remove = function() {',
-        '    console.error(' + message + ');',
-        '    return null;',
-        '};',
-        ''
-    ].join('\n');
-}
+function transformSync(sassOpts, autoprefixerOpts) {
+    sassOpts = _.extend({}, SASS_DEFAULTS, sassOpts);
+    autoprefixerOpts = _.extend({}, AUTOPREFIXER_DEFAULTS, autoprefixerOpts);
 
-function transformSync(opts) {
-    opts = _.defaults(opts, SASS_DEFAULTS);
+    var result = sass.renderSync(sassOpts);
+    var css = result.css.toString();
+    css = postcss( [autoprefixer(autoprefixerOpts)] ).process(css).css;
 
-    var module;
     // JSON.stringify protects against unescaped quotes winding up
     // in the modules that get generated.
-    try {
-        var result = sass.renderSync(opts);
-        module = sassrModuleWith(JSON.stringify(result.css.toString()));
-    } catch (error) {
-        module = errorModuleWith(JSON.stringify(error.message));
-    }
-
-    return module;
+    return sassrModuleWith(JSON.stringify(css));
 }
 
 function sassrSync(file, opts) {
@@ -92,7 +70,9 @@ function sassrSync(file, opts) {
         return through();
     }
 
-    opts = _.omit(_.defaults({}, opts, SASS_DEFAULTS), OMIT_FIELDS);
+    opts = opts || {};
+    var sassOpts = _.extend({}, SASS_DEFAULTS, opts.sass);
+    var autoprefixerOpts = _.extend({}, AUTOPREFIXER_DEFAULTS, opts.autoprefixer);
 
     var buffers = [];
 
@@ -107,38 +87,40 @@ function sassrSync(file, opts) {
         var src = Buffer.concat(buffers).toString();
         var paths = [
             path.dirname(file)
-        ].concat(opts.includePaths);
+        ].concat(sassOpts.includePaths);
 
-        opts = _.defaults({
+        sassOpts = _.defaults({
             data: src,
             includePaths: paths
         }, opts);
 
-        var module = transformSync(opts);
-        var error = module.match(ERROR_RE) && module.match(ERROR_RE)[1];
-
-        self.push(module);
-        if (error) {
-            self.emit('error', error);
+        try {
+            self.push(transformSync(sassOpts, autoprefixerOpts));
+            next();
+        } catch (error) {
+            self.emit('error', JSON.stringify(error.message));
         }
-
-        next();
     }
 
     return through(push, end);
 }
 
-function transform(opts, done) {
-    opts = _.defaults(opts, SASS_DEFAULTS);
+function transform(sassOpts, autoprefixerOpts, done) {
+    sassOpts = _.extend({}, SASS_DEFAULTS, sassOpts);
+    autoprefixerOpts = _.defaults({}, AUTOPREFIXER_DEFAULTS, autoprefixerOpts);
 
-    sass.render(opts, function(error, result) {
-        // JSON.stringify protects against unescaped quotes winding up
-        // in the modules that get generated.
-        var module = (error) ?
-            errorModuleWith(JSON.stringify(error.message)) :
-            sassrModuleWith(JSON.stringify(result.css.toString()));
+    sass.render(sassOpts, function(error, result) {
+        if (error) {
+            return done(error);
+        }
 
-        done(error, module);
+        postcss( [autoprefixer(autoprefixerOpts)] )
+            .process(result.css.toString())
+            .then(function(result) {
+                // JSON.stringify protects against unescaped quotes winding up
+                // in the modules that get generated.
+                done(error, sassrModuleWith(JSON.stringify(result.css)));
+            });
     });
 }
 
@@ -147,7 +129,9 @@ function sassr(file, opts) {
         return through();
     }
 
-    opts = _.omit(_.defaults({}, opts, SASS_DEFAULTS), OMIT_FIELDS);
+    opts = opts || {};
+    var sassOpts = _.extend({}, SASS_DEFAULTS, opts.sass);
+    var autoprefixerOpts = _.extend({}, AUTOPREFIXER_DEFAULTS, opts.autoprefixer);
 
     var buffers = [];
 
@@ -162,21 +146,20 @@ function sassr(file, opts) {
         var src = Buffer.concat(buffers).toString();
         var paths = [
             path.dirname(file)
-        ].concat(opts.includePaths);
+        ].concat(sassOpts.includePaths);
 
-        opts = _.defaults({
+        sassOpts = _.defaults({
             data: src,
             includePaths: paths
-        }, opts);
+        }, sassOpts);
 
-        transform(opts, function(error, module) {
-
-            self.push(module);
-            if (error) {
+        transform(sassOpts, autoprefixerOpts, function(error, module) {
+            if (!error) {
+                self.push(module);
+                next();
+            } else {
                 self.emit('error', JSON.stringify(error.message));
             }
-
-            next();
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "sass",
     "css",
     "styles",
-    "Browserify",
+    "browserify",
+    "autoprefixer",
     "transform",
     "scss"
   ],
@@ -24,13 +25,15 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "3.10.x",
-    "node-sass": "3.2.x",
-    "through2": "2.0.x"
+    "autoprefixer": "^5.2.0",
+    "lodash": "^3.10.0",
+    "node-sass": "^3.2.0",
+    "postcss": "^5.0.2",
+    "through2": "^2.0.0"
   },
   "devDependencies": {
-    "chai": "3.2.x",
-    "concat-stream": "1.5.x",
-    "mocha": "2.2.x"
+    "chai": "^3.2.0",
+    "concat-stream": "^1.5.0",
+    "mocha": "^2.2.5"
   }
 }

--- a/test/fixtures/autoprefixed.scss
+++ b/test/fixtures/autoprefixed.scss
@@ -1,0 +1,3 @@
+.righty {
+    transform: rotate(90deg);
+}


### PR DESCRIPTION
This has three significant-ish changes.

First of all, I killed the wonky error modules. I don't get it, and I don't like them. Maybe there's a reason they need to stick around? I can add them back if there's a compelling use case? I dunno.

Second of all, I added postcss and autoprefixer. It's always on, but you can disable autoprefixing it in the configuration...not that anyone would want to in the first place, most likely.

Third of all, since we can now configure both sass and autoprefixer, I changed the config to split out sass options and autoprefixer options into their own keys. This is going to be a breaking change, but I think it's for the best in the long run.

Thoughts? Version 0.1.0 bump? You betcha.

cc. @mysterycommand @tholman
