### PR TITLE
Remove css error modules

### DIFF
--- a/lib/sassr.js
+++ b/lib/sassr.js
@@ -11,8 +11,6 @@ var SASS_DEFAULTS = {
     includePaths: [],
     outputStyle: 'compressed'
 };
-var OMIT_FIELDS = ['file', 'success', 'error'];
-var ERROR_RE = /console\.error\((.*?)\)/;
 
 function sassrModuleWith(css) {
     return [
@@ -51,40 +49,12 @@ function sassrModuleWith(css) {
     ].join('\n');
 }
 
-function errorModuleWith(message) {
-    return [
-        '\'use strict\';',
-        '',
-        'exports.getStyleElement = function() {',
-        '    return null;',
-        '};',
-        '',
-        'exports.getCSSText = function() {',
-        '    return \'\';',
-        '};',
-        '',
-        'exports.append = exports.remove = function() {',
-        '    console.error(' + message + ');',
-        '    return null;',
-        '};',
-        ''
-    ].join('\n');
-}
-
 function transformSync(opts) {
     opts = _.defaults(opts, SASS_DEFAULTS);
 
-    var module;
     // JSON.stringify protects against unescaped quotes winding up
     // in the modules that get generated.
-    try {
-        var result = sass.renderSync(opts);
-        module = sassrModuleWith(JSON.stringify(result.css.toString()));
-    } catch (error) {
-        module = errorModuleWith(JSON.stringify(error.message));
-    }
-
-    return module;
+    return sassrModuleWith(JSON.stringify(sass.renderSync(opts).css.toString()));
 }
 
 function sassrSync(file, opts) {
@@ -92,7 +62,7 @@ function sassrSync(file, opts) {
         return through();
     }
 
-    opts = _.omit(_.defaults({}, opts, SASS_DEFAULTS), OMIT_FIELDS);
+    opts = _.extend({}, SASS_DEFAULTS, opts);
 
     var buffers = [];
 
@@ -114,31 +84,28 @@ function sassrSync(file, opts) {
             includePaths: paths
         }, opts);
 
-        var module = transformSync(opts);
-        var error = module.match(ERROR_RE) && module.match(ERROR_RE)[1];
-
-        self.push(module);
-        if (error) {
-            self.emit('error', error);
+        try {
+            self.push(transformSync(opts));
+            next();
+        } catch (error) {
+            self.emit('error', JSON.stringify(error.message));
         }
-
-        next();
     }
 
     return through(push, end);
 }
 
 function transform(opts, done) {
-    opts = _.defaults(opts, SASS_DEFAULTS);
+    opts = _.extend({}, SASS_DEFAULTS, opts);
 
     sass.render(opts, function(error, result) {
+        if (error) {
+            return done(error);
+        }
+
         // JSON.stringify protects against unescaped quotes winding up
         // in the modules that get generated.
-        var module = (error) ?
-            errorModuleWith(JSON.stringify(error.message)) :
-            sassrModuleWith(JSON.stringify(result.css.toString()));
-
-        done(error, module);
+        done(error, sassrModuleWith(JSON.stringify(result.css.toString())));
     });
 }
 
@@ -147,7 +114,7 @@ function sassr(file, opts) {
         return through();
     }
 
-    opts = _.omit(_.defaults({}, opts, SASS_DEFAULTS), OMIT_FIELDS);
+    opts = _.extend({}, SASS_DEFAULTS, opts);
 
     var buffers = [];
 
@@ -170,13 +137,13 @@ function sassr(file, opts) {
         }, opts);
 
         transform(opts, function(error, module) {
-
             self.push(module);
-            if (error) {
+            if (!error) {
+                self.push(module);
+                next();
+            } else {
                 self.emit('error', JSON.stringify(error.message));
             }
-
-            next();
         });
     }
 

--- a/lib/sassr.js
+++ b/lib/sassr.js
@@ -50,7 +50,7 @@ function sassrModuleWith(css) {
 }
 
 function transformSync(opts) {
-    opts = _.defaults(opts, SASS_DEFAULTS);
+    opts = _.extend({}, SASS_DEFAULTS, opts);
 
     // JSON.stringify protects against unescaped quotes winding up
     // in the modules that get generated.
@@ -74,15 +74,9 @@ function sassrSync(file, opts) {
     function end(next) {
         /* jshint validthis: true */
         var self = this;
-        var src = Buffer.concat(buffers).toString();
-        var paths = [
-            path.dirname(file)
-        ].concat(opts.includePaths);
 
-        opts = _.defaults({
-            data: src,
-            includePaths: paths
-        }, opts);
+        opts.includePaths.unshift(path.dirname(file));
+        opts.data = Buffer.concat(buffers).toString();
 
         try {
             self.push(transformSync(opts));
@@ -126,15 +120,9 @@ function sassr(file, opts) {
     function end(next) {
         /* jshint validthis: true */
         var self = this;
-        var src = Buffer.concat(buffers).toString();
-        var paths = [
-            path.dirname(file)
-        ].concat(opts.includePaths);
 
-        opts = _.defaults({
-            data: src,
-            includePaths: paths
-        }, opts);
+        opts.includePaths.unshift(path.dirname(file));
+        opts.data = Buffer.concat(buffers).toString();
 
         transform(opts, function(error, module) {
             self.push(module);

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "3.10.x",
-    "node-sass": "3.2.x",
-    "through2": "2.0.x"
+    "lodash": "^3.10.0",
+    "node-sass": "^3.2.0",
+    "through2": "^2.0.0"
   },
   "devDependencies": {
-    "chai": "3.2.x",
-    "concat-stream": "1.5.x",
-    "mocha": "2.2.x"
+    "chai": "^3.2.0",
+    "concat-stream": "^1.5.0",
+    "mocha": "^2.2.5"
   }
 }

--- a/test/sassr.test.js
+++ b/test/sassr.test.js
@@ -39,7 +39,6 @@ describe('sassr', function() {
     function assertCSSText(source, cssText, callback) {
         callback = callback || function() {};
         var module = testUtils.loadAsModule(source);
-        assert.equal(module.getCSSText(), cssText);
         try {
             assert.equal(module.getCSSText(), cssText);
             callback();

--- a/test/sassr.test.js
+++ b/test/sassr.test.js
@@ -18,28 +18,34 @@ var EXPECTED_ERROR = '"property \\"We\\" must be followed by a \':\'"';
 describe('sassr', function() {
     var cssPaths = {
         good: require.resolve('./fixtures/good.css'),
-        bad: require.resolve('./fixtures/bad.css')
+        bad: require.resolve('./fixtures/bad.css'),
     };
     var cssSources = {
         good: fs.readFileSync(cssPaths.good).toString(),
-        bad: fs.readFileSync(cssPaths.bad).toString()
+        bad: fs.readFileSync(cssPaths.bad).toString(),
     };
 
     var scssPaths = {
         good: require.resolve('./fixtures/good.scss'),
-        bad: require.resolve('./fixtures/bad.scss')
+        bad: require.resolve('./fixtures/bad.scss'),
     };
     var scssSources = {
         good: fs.readFileSync(scssPaths.good).toString(),
-        bad: fs.readFileSync(scssPaths.bad).toString()
+        bad: fs.readFileSync(scssPaths.bad).toString(),
     };
 
     var txtPath = require.resolve('./fixtures/not-css.txt');
 
     function assertCSSText(source, cssText, callback) {
+        callback = callback || function() {};
         var module = testUtils.loadAsModule(source);
         assert.equal(module.getCSSText(), cssText);
-        if (callback) { callback(); }
+        try {
+            assert.equal(module.getCSSText(), cssText);
+            callback();
+        } catch (error) {
+            callback(error);
+        }
     }
 
     it('should load and export sync, transform, and transformSync', function() {
@@ -51,7 +57,7 @@ describe('sassr', function() {
 
     describe('sassr', function() {
         function sassrize(path, opts, done) {
-            fs.createReadStream(path)
+            return fs.createReadStream(path)
                 .pipe(sassr(path, opts))
                 .on('error', function(error) {
                     done(error);
@@ -80,14 +86,14 @@ describe('sassr', function() {
             });
         });
 
-        it('should return an error message on bad CSS', function(done) {
+        it('should error on bad CSS', function(done) {
             sassrize(cssPaths.bad, {}, function(error) {
                 assert.equal(error, EXPECTED_ERROR);
                 done();
             });
         });
 
-        it('should return an error message on bad SCSS', function(done) {
+        it('should error on bad SCSS', function(done) {
             sassrize(scssPaths.bad, {}, function(error) {
                 assert.equal(error, EXPECTED_ERROR);
                 done();
@@ -126,14 +132,14 @@ describe('sassr', function() {
             });
         });
 
-        it('should return an error message on bad CSS', function(done) {
+        it('should error on bad CSS', function(done) {
             sassrizeSync(cssPaths.bad, {}, function(error) {
                 assert.equal(error, EXPECTED_ERROR);
                 done();
             });
         });
 
-        it('should return an error message on bad SCSS', function(done) {
+        it('should error on bad SCSS', function(done) {
             sassrizeSync(scssPaths.bad, {}, function(error) {
                 assert.equal(error, EXPECTED_ERROR);
                 done();
@@ -164,25 +170,29 @@ describe('sassr', function() {
             });
         });
 
-        it('should fail gracefully on bad CSS', function(done) {
+        it('should error on bad CSS', function(done) {
             sassr.transform({
                 data: cssSources.bad,
                 includePaths: [
                     path.dirname(cssPaths.bad)
                 ]
             }, function(error, module) {
-                assertCSSText(module, '', done);
+                assert.instanceOf(error, Error);
+                assert.isUndefined(module);
+                done();
             });
         });
 
-        it('should fail gracefully on bad SCSS', function(done) {
+        it('should error on bad SCSS', function(done) {
             sassr.transform({
                 data: scssSources.bad,
                 includePaths: [
                     path.dirname(scssPaths.bad)
                 ]
             }, function(error, module) {
-                assertCSSText(module, '', done);
+                assert.instanceOf(error, Error);
+                assert.isUndefined(module);
+                done();
             });
         });
     });
@@ -210,26 +220,26 @@ describe('sassr', function() {
             assertCSSText(module, EXPECTED_GOOD_SCSS);
         });
 
-        it('should fail gracefully on bad CSS', function() {
-            var module = sassr.transformSync({
-                data: cssSources.bad,
-                includePaths: [
-                    path.dirname(cssPaths.bad)
-                ]
+        it('should error on bad CSS', function() {
+            assert.throws(function() {
+                sassr.transformSync({
+                    data: cssSources.bad,
+                    includePaths: [
+                        path.dirname(cssPaths.bad)
+                    ]
+                }, {});
             });
-
-            assertCSSText(module, '');
         });
 
-        it('should fail gracefully on bad SCSS', function() {
-            var module = sassr.transformSync({
-                data: scssSources.bad,
-                includePaths: [
-                    path.dirname(scssPaths.bad)
-                ]
+        it('should error on bad SCSS', function() {
+            assert.throws(function() {
+                sassr.transformSync({
+                    data: scssSources.bad,
+                    includePaths: [
+                        path.dirname(scssPaths.bad)
+                    ]
+                }, {});
             });
-
-            assertCSSText(module, '');
         });
     });
 

--- a/test/sassr.test.js
+++ b/test/sassr.test.js
@@ -226,7 +226,7 @@ describe('sassr', function() {
                     includePaths: [
                         path.dirname(cssPaths.bad)
                     ]
-                }, {});
+                });
             });
         });
 
@@ -237,7 +237,7 @@ describe('sassr', function() {
                     includePaths: [
                         path.dirname(scssPaths.bad)
                     ]
-                }, {});
+                });
             });
         });
     });


### PR DESCRIPTION
Removes the weird error modules thing that this was doing in favor of just returning the error or throwing. Tests updated to reflect this.