### PR TITLE
Add transformCSS callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Using [npm](http://npmjs.org):
 
 ```shell
-npm install -g sassr
+npm install sassr
 ```
 
 # usage
@@ -71,4 +71,19 @@ var b = browserify()
     .add('./some.js')
     .transform(sassConfig, sassr)
     .bundle().pipe(process.stdout);
+```
+
+## what if i want to use postcss/[whatever cool thing] too?
+
+Glad you asked! You can specify a function for `cssPostProcessor` and hook up whatever you want to it:
+
+```js
+var prefixer = postcss([ autoprefixer ]);
+var sassConfig = {
+    cssPostProcessor: function(css, callback) {
+      prefixer.process(css).then(function(result) {
+          callback(null, result);
+      });
+    }
+};
 ```

--- a/lib/sassr.js
+++ b/lib/sassr.js
@@ -54,11 +54,11 @@ function transformSync(opts) {
 
     var css = sass.renderSync(opts).css.toString();
 
-    if (_.isFunction(opts.transformCSS)) {
-        css = opts.transformCSS(css);
+    if (_.isFunction(opts.cssPostProcessor)) {
+        css = opts.cssPostProcessor(css);
 
         if (!_.isString(css)) {
-            throw new Error('To use transformCSS synchronously, you must return a string, NOT provide a callback!');
+            throw new Error('To use cssPostProcessor synchronously, you must return a string, NOT provide a callback!');
         }
     }
 
@@ -102,28 +102,23 @@ function sassrSync(file, opts) {
 function transform(opts, done) {
     opts = _.extend({}, SASS_DEFAULTS, opts);
 
-    sass.render(opts, function(error, result) {
+    function cssPostProcessorDone(error, css) {
         if (error) {
             done(error);
             return;
         }
 
-        var onDoneCallback = function(error, css) {
-            if (error) {
-                done(error);
-                return;
-            }
+        // JSON.stringify protects against unescaped quotes winding up
+        // in the modules that get generated.
+        done(error, sassrModuleWith(JSON.stringify(css)));
+    }
 
-            // JSON.stringify protects against unescaped quotes winding up
-            // in the modules that get generated.
-            done(error, sassrModuleWith(JSON.stringify(css)));
-        };
-
-        var css = result.css.toString();
-        if (_.isFunction(opts.transformCSS)) {
-            opts.transformCSS(css, onDoneCallback);
+    sass.render(opts, function(error, result) {
+        var css = error ? '' : result.css.toString();
+        if (error || !_.isFunction(opts.cssPostProcessor)) {
+            cssPostProcessorDone(error, css);
         } else {
-            onDoneCallback(error, css);
+            opts.cssPostProcessor(css, cssPostProcessorDone);
         }
     });
 }

--- a/lib/sassr.js
+++ b/lib/sassr.js
@@ -52,9 +52,19 @@ function sassrModuleWith(css) {
 function transformSync(opts) {
     opts = _.extend({}, SASS_DEFAULTS, opts);
 
+    var css = sass.renderSync(opts).css.toString();
+
+    if (_.isFunction(opts.transformCSS)) {
+        css = opts.transformCSS(css);
+
+        if (!_.isString(css)) {
+            throw new Error('To use transformCSS synchronously, you must return a string, NOT provide a callback!');
+        }
+    }
+
     // JSON.stringify protects against unescaped quotes winding up
     // in the modules that get generated.
-    return sassrModuleWith(JSON.stringify(sass.renderSync(opts).css.toString()));
+    return sassrModuleWith(JSON.stringify(css));
 }
 
 function sassrSync(file, opts) {
@@ -72,7 +82,7 @@ function sassrSync(file, opts) {
     }
 
     function end(next) {
-        /* jshint validthis: true */
+        // jshint validthis: true
         var self = this;
 
         opts.includePaths.unshift(path.dirname(file));
@@ -94,12 +104,27 @@ function transform(opts, done) {
 
     sass.render(opts, function(error, result) {
         if (error) {
-            return done(error);
+            done(error);
+            return;
         }
 
-        // JSON.stringify protects against unescaped quotes winding up
-        // in the modules that get generated.
-        done(error, sassrModuleWith(JSON.stringify(result.css.toString())));
+        var onDoneCallback = function(error, css) {
+            if (error) {
+                done(error);
+                return;
+            }
+
+            // JSON.stringify protects against unescaped quotes winding up
+            // in the modules that get generated.
+            done(error, sassrModuleWith(JSON.stringify(css)));
+        };
+
+        var css = result.css.toString();
+        if (_.isFunction(opts.transformCSS)) {
+            opts.transformCSS(css, onDoneCallback);
+        } else {
+            onDoneCallback(error, css);
+        }
     });
 }
 
@@ -118,7 +143,7 @@ function sassr(file, opts) {
     }
 
     function end(next) {
-        /* jshint validthis: true */
+        // jshint validthis: true
         var self = this;
 
         opts.includePaths.unshift(path.dirname(file));

--- a/test/sassr.test.js
+++ b/test/sassr.test.js
@@ -85,6 +85,16 @@ describe('sassr', function() {
             });
         });
 
+        it('should use transformCSS option asynchronously', function(done) {
+            sassrize(scssPaths.good, {
+                transformCSS: function(css, callback) {
+                    callback(null, css);
+                }
+            }, function(module) {
+                assertCSSText(module, EXPECTED_GOOD_SCSS, done);
+            });
+        });
+
         it('should error on bad CSS', function(done) {
             sassrize(cssPaths.bad, {}, function(error) {
                 assert.equal(error, EXPECTED_ERROR);
@@ -128,6 +138,16 @@ describe('sassr', function() {
             sassrizeSync(txtPath, {}, function(module) {
                 assert.equal(module, 'This is not CSS.\n');
                 done();
+            });
+        });
+
+        it('should use transformCSS option synchronously', function(done) {
+            sassrizeSync(scssPaths.good, {
+                transformCSS: function(css) {
+                    return css;
+                }
+            }, function(module) {
+                assertCSSText(module, EXPECTED_GOOD_SCSS, done);
             });
         });
 
@@ -237,6 +257,20 @@ describe('sassr', function() {
                     includePaths: [
                         path.dirname(scssPaths.bad)
                     ]
+                });
+            });
+        });
+
+        it('should error when transformCSS option does not return a string', function() {
+            assert.throws(function() {
+                sassr.transformSync({
+                    data: scssSources.good,
+                    includePaths: [
+                        path.dirname(scssPaths.good)
+                    ],
+                    transformCSS: function(css) {
+                        return undefined;
+                    }
                 });
             });
         });

--- a/test/sassr.test.js
+++ b/test/sassr.test.js
@@ -85,9 +85,9 @@ describe('sassr', function() {
             });
         });
 
-        it('should use transformCSS option asynchronously', function(done) {
+        it('should use cssPostProcessor option asynchronously', function(done) {
             sassrize(scssPaths.good, {
-                transformCSS: function(css, callback) {
+                cssPostProcessor: function(css, callback) {
                     callback(null, css);
                 }
             }, function(module) {
@@ -141,9 +141,9 @@ describe('sassr', function() {
             });
         });
 
-        it('should use transformCSS option synchronously', function(done) {
+        it('should use cssPostProcessor option synchronously', function(done) {
             sassrizeSync(scssPaths.good, {
-                transformCSS: function(css) {
+                cssPostProcessor: function(css) {
                     return css;
                 }
             }, function(module) {
@@ -261,14 +261,14 @@ describe('sassr', function() {
             });
         });
 
-        it('should error when transformCSS option does not return a string', function() {
+        it('should error when cssPostProcessor option does not return a string', function() {
             assert.throws(function() {
                 sassr.transformSync({
                     data: scssSources.good,
                     includePaths: [
                         path.dirname(scssPaths.good)
                     ],
-                    transformCSS: function(css) {
+                    cssPostProcessor: function(css) {
                         return undefined;
                     }
                 });


### PR DESCRIPTION
This introduces a `transformCSS` option that can be used to add additional CSS postprocessing. When used synchronously, `transformCSS` takes a CSS string and returns the modified string. When used asynchronously, `transformCSS` takes a CSS string and callback, which it should invoke with the modified string when any postprocessing is done.